### PR TITLE
Add syntax highlighting to REPL.

### DIFF
--- a/raku-mode.el
+++ b/raku-mode.el
@@ -77,10 +77,6 @@
   (setq-local comment-start-skip "#+ *")
   (setq-local comment-use-syntax t)
   (setq-local comment-end "")
-   ;; REPL
-  (setq comint-prompt-regexp raku-prompt-regexp)
-  (setq comint-prompt-read-only t)
-  (set (make-local-variable 'paragraph-start) raku-prompt-regexp)
   ;; Indentation (see SMIE in the Emacs manual)
   ;; TODO add rules for HEREDOC indentation
   (smie-setup raku-smie-grammar #'raku-smie-rules

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -5,6 +5,7 @@
 
 ;;; Code:
 (require 'comint)
+(require 'raku-font-lock)
 
 (defcustom raku-exec-path "raku"
   "Raku executable path."
@@ -22,6 +23,26 @@
 (defvar raku-buffer-name "Raku REPL"
   "Buffer name for `run-raku.")
 
+(define-derived-mode raku-repl-mode comint-mode "Raku"
+  "Major mode for `run-raku'."
+  ;; Set up the prompt and make it read only.
+  (setq-local comint-prompt-regexp raku-prompt-regexp)
+  (setq-local comint-prompt-readonly t)
+  ;; See raku-mode.el.
+  (setq-local syntax-propertize-function #'raku-syntax-propertize)
+  (add-hook 'syntax-propertize-extend-region-functions #'syntax-propertize-multiline nil 'local)
+  (setq-local font-lock-syntactic-face-function #'raku-font-lock-syntactic-face)
+  (setq-local font-lock-defaults '(raku-font-lock-keywords nil nil))
+  (add-hook 'raku-mode-hook 'imenu-add-menubar-index)
+  (setq imenu-generic-expression raku-imenu-generic-expression
+      imenu-case-fold-search nil)
+  (setq-local comment-start "#")
+  (setq-local comment-start-skip "#+ *")
+  (setq-local comment-use-syntax t)
+  (setq-local comment-end "")
+  ;; Don't jump beyond the prompt with M-{ or M-}.
+  (setq-local paragraph-start raku-prompt-regexp))
+
 (defun run-raku ()
   "Run an inferior instance of `raku' inside Emacs."
   (interactive)
@@ -33,6 +54,8 @@
                         raku-exec-path
                         '()
                         (split-string raku-exec-arguments))))
+    (with-current-buffer buffer
+      (raku-repl-mode))
     (display-buffer buffer)))
 
 (defun raku-comint-get-process ()


### PR DESCRIPTION
Remove the comint-related variables from the major mode as we need a
separate comint mode.

It does highlight syntax in string output, I don't think we can easily fix that.