### PR TITLE
Add missing 's' to parent customization group name.

### DIFF
--- a/raku-mode.el
+++ b/raku-mode.el
@@ -36,7 +36,7 @@
 (defgroup raku nil
   "Major mode for editing Raku code."
   :prefix "raku-"
-  :group 'language)
+  :group 'languages)
 
 (require 'raku-detect)
 (require 'raku-font-lock)


### PR DESCRIPTION
There is a customization group called "languages", not "language".