### PR TITLE
Add raku-reload-repl-with-module

### DIFF
--- a/raku-mode.el
+++ b/raku-mode.el
@@ -49,7 +49,7 @@
     (define-key map (kbd "C-c C-c") 'raku-send-line-to-repl)
     (define-key map (kbd "C-c C-r") 'raku-send-region-to-repl)
     (define-key map (kbd "C-c C-h") 'raku-send-buffer-to-repl)
-    (define-key map (kbd "C-c C-m") 'raku-reload-repl-with-module)
+    (define-key map (kbd "C-c C-l") 'raku-reload-repl-with-module)
     map)
   "Keymap for `raku-mode'.")
 

--- a/raku-mode.el
+++ b/raku-mode.el
@@ -49,6 +49,7 @@
     (define-key map (kbd "C-c C-c") 'raku-send-line-to-repl)
     (define-key map (kbd "C-c C-r") 'raku-send-region-to-repl)
     (define-key map (kbd "C-c C-h") 'raku-send-buffer-to-repl)
+    (define-key map (kbd "C-c C-m") 'raku-reload-repl-with-module)
     map)
   "Keymap for `raku-mode'.")
 
@@ -57,7 +58,8 @@
   '("Raku"
     ["Send line to repl" raku-send-line-to-repl]
     ["Send region to repl" raku-send-region-to-repl]
-    ["Send buffer to repl" raku-send-buffer-to-repl]))
+    ["Send buffer to repl" raku-send-buffer-to-repl]
+    ["Reload repl with module" raku-reload-repl-with-module]))
 
 ;;;###autoload
 (define-derived-mode raku-mode prog-mode "Raku"

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -84,6 +84,19 @@
         (raku-send-string-to-repl buf))
     (message "No region selected")))
 
+(defun raku-reload-repl-with-module()
+  "Reloads the Raku REPL with the module with the name of the current file."
+  (interactive)
+  (let ((raku-exec-arguments (concat "-I "
+                                     (file-name-directory buffer-file-name)
+                                     " -M "
+                                     (file-name-base))))
+    (when (raku-comint-get-process)
+      (interrupt-process (raku-comint-get-process))
+      (sleep-for .01))    
+    (run-raku)
+    (raku-send-string-to-repl "")))
+
 (defun raku-send-buffer-to-repl ()
   "Send a buffer to the repl."
   (interactive)


### PR DESCRIPTION
Thanks for your work on this – `raku-mode` definitely makes editing Raku code a lot more -Ofun :+1: 

One issue I've run into, however, is that I frequently want to restart my REPL to test out changes in a module I'm developing, which then requires re `use`ing the module and its directory.  This PR adds a function that automates the process of re-loading the current module (or, rather, a module with the same name as the current file).  It also adds menu and keyboard shortcuts for the new function.

I hope other find this helpful.