### PR TITLE
Fix qe comparator highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 perl6-mode-pkg.el
 *~
+ert-profile

--- a/raku-font-lock.el
+++ b/raku-font-lock.el
@@ -181,7 +181,7 @@
                     "tighter" "looser" "equiv" "assoc" "required")))
         (operator-word
          . ,(rx (or "div" "xx" "x" "mod" "also" "leg" "cmp" "before" "after" "eq"
-                    "ne" "le" "lt" "not" "gt" "eqv" "ff" "fff" "and" "andthen"
+                    "ne" "le" "lt" "not" "gt" "ge" "eqv" "ff" "fff" "and" "andthen"
                     "or" "xor" "orelse" "extra" "lcm" "gcd" "o")))
         (operator-char . ,(rx (any "-:+/*~?|=^!%&,<>».;\\∈∉∋∌∩∪≼≽⊂⊃⊄⊅⊆⊇⊈⊉⊍⊎⊖∅∘")))
         (set-operator


### PR DESCRIPTION
I'm learning Raku, and using this lovely raku-mode for working inside emacs. Following thinking in Raku book at some point it teaches strings comparators and I see the following problem with ge operator:

<img width="1680" alt="Captura_error" src="https://user-images.githubusercontent.com/2518346/92038565-e65b8180-ed73-11ea-9be6-4ca2f80f6e7e.png">

So I tried to fix it, and it seems to work:

<img width="1680" alt="Captura_corregido" src="https://user-images.githubusercontent.com/2518346/92038606-f3787080-ed73-11ea-9ed4-2852d418acc5.png">

I also added an ert file to .gitignore. hope it helps