### PR TITLE
An attempt to resolve an error on indenting.

### DIFF
--- a/raku-indent.el
+++ b/raku-indent.el
@@ -55,10 +55,6 @@
     (`(:elem . basic) raku-indent-offset)
     (`(:elem . arg) 0)
     (`(:list-intro . ,(or `";" `"")) t) ;"" stands for BOB (bug#15467).
-    (`(:before . "{")
-     (when (smie-rule-hanging-p)
-       (smie-backward-sexp ";")
-       (smie-indent-virtual)))
     (`(:before . ,(or "{" "("))
      (if (smie-rule-hanging-p) (smie-rule-parent 0)))))
 


### PR DESCRIPTION
Fix issue #23

When indenting something like

    if %h{"foo"} {
        ....... (press tab here)
    }

This error happens.

    (error "Lisp nesting exceeds ‘max-lisp-eval-depth’")

Note here that while the fix does makes the error go away, it is not
entirely certain whether it breaks the indentation for some other
cases.

But I think we could live with this until we found what's broken.