### PR TITLE
function to load a whole file to the repl

### DIFF
--- a/raku-repl.el
+++ b/raku-repl.el
@@ -92,5 +92,14 @@
                                              (point-max))))
     (raku-send-string-to-repl buf)))
 
+(defun raku-send-file-to-repl (filename)
+  "Send the file to the repl."
+  (interactive (list
+		(read-file-name "Load file: " nil nil
+				nil (buffer-file-name))))
+  (run-raku)
+  (let ((str (concat "EVALFILE \"" (expand-file-name filename) "\";")))
+    (raku-send-string-to-repl str)))
+
 (provide 'raku-repl)
 ;;; raku-repl.el ends here


### PR DESCRIPTION
Raku repl is a bit buggy.
It is cumbersome and error prone to evaluate the buffer line-by-line using `raku-send-buffer-to-repl`. 

A couple instances of errors caused by repl line-by-line evaluation.
https://github.com/Raku/raku-mode/issues/42#issue-701228997
https://stackoverflow.com/questions/68426875/compilation-error-only-when-using-the-repl

This is a function to just use `EVALFILE` routine and load the selected file.

You can try loading this using `raku-send-buffer-to-repl` and see that it is error prone.
```
class A {
    method a () {
    return 1;
    }
}

class B {
    method b () {
    return 2;
    }
}

print "hello\n";
```