### PR TITLE
Remove pkg-info dependency

### DIFF
--- a/nqp-mode.el
+++ b/nqp-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/hinrik/perl6-mode
 ;; Keywords: languages
 ;; Version: 0.1-git
-;; Package-Requires: ((emacs "24.4") (pkg-info "0.1"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -30,8 +30,6 @@
 ;; Currently only provides very basic syntax highlighting.
 
 ;;; Code:
-
-(declare-function pkg-info-version-info "pkg-info" (library))
 
 (defgroup raku nil
   "Major mode for editing Raku code."

--- a/raku-mode.el
+++ b/raku-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/hinrik/perl6-mode
 ;; Keywords: languages
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "24.4") (pkg-info "0.1"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -30,8 +30,6 @@
 ;; Currently only provides very basic syntax highlighting.
 
 ;;; Code:
-
-(declare-function pkg-info-version-info "pkg-info" (library))
 
 (defgroup raku nil
   "Major mode for editing Raku code."


### PR DESCRIPTION
Hi, I am preparing this package for [NonGNU ELPA](https://elpa.nongnu.org/), and would like to avoid packaging pkg-info. From what I see, the function `pkg-info-version-info` is just declared but not used. I have removed it locally, and the package seems to work with no issues, so I'd like to suggest the following patch.