### PR TITLE
Temporary fix for Issue #43

### DIFF
--- a/raku-font-lock.el
+++ b/raku-font-lock.el
@@ -491,7 +491,7 @@ Takes arguments START and END which delimit the region to propertize."
       ((raku-rx (or set-operator rsxz-operator reduce-operator hyper-operator))
        (0 (ignore (raku-add-font-lock-hint 'raku-metaoperator 0))))
       ;; angle-bracketed quoting construct
-      ((rx (or (1+ "<") (1+ "«")))
+      ((rx (1+ "«"))
        (0 (ignore (raku-syntax-propertize-angles (match-string 0)))))
       ;; backslashes outside strings/comments are punctuation, not escapes
       ((rx "\\")


### PR DESCRIPTION
Angle brackets are no longer treated as string delimiters, which makes
the `$<foobar>` syntax slightly uglier but allows us to use less than
signs in code without the rest of the file blowing up.