### PR TITLE
Add switch-to-raku function to REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ keybindings are available to interact with the REPL:
 * <kbd>C-c C-l</kbd>: Send the current **l**ine to the REPL
 * <kbd>C-c C-r</kbd>: Send the selected **r**egion to the REPL
 * <kbd>C-c C-b</kbd>: Send the whole **b**uffer to the REPL
+* <kbd>C-c C-z</kbd>: Switch to the REPL buffer
 
 The REPL will start if needed with this keybindings.
 

--- a/raku-mode.el
+++ b/raku-mode.el
@@ -47,6 +47,7 @@
     (define-key map (kbd "C-c C-l") 'raku-send-line-to-repl)
     (define-key map (kbd "C-c C-r") 'raku-send-region-to-repl)
     (define-key map (kbd "C-c C-b") 'raku-send-buffer-to-repl)
+    (define-key map (kbd "C-c C-z") 'switch-to-raku)
     map)
   "Keymap for `raku-mode'.")
 

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -65,7 +65,7 @@
 (defun switch-to-raku (eob-p)
   "Start a Raku REPL, or switch to a running one.
 Reuses an existing REPL window if visible, otherwise switches in
-current window.  With prefix argument EOB-P, move point to the end of
+current window. With prefix argument EOB-P, move point to the end of
 the buffer."
   (interactive "P")
   (let* ((buf-name (format "*%s*" raku-buffer-name))

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -7,8 +7,6 @@
 (require 'comint)
 (require 'raku-font-lock)
 
-(define-key raku-repl-mode-map (kbd "C-c C-z") #'switch-to-raku)
-
 (defcustom raku-exec-path "raku"
   "Raku executable path."
   :type 'string
@@ -44,6 +42,8 @@
   (setq-local comment-end "")
   ;; Don't jump beyond the prompt with M-{ or M-}.
   (setq-local paragraph-start raku-prompt-regexp))
+
+(define-key raku-repl-mode-map (kbd "C-c C-z") #'switch-to-raku)
 
 (defun run-raku ()
   "Run an inferior instance of `raku' inside Emacs."

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -63,7 +63,7 @@
   (get-process raku-buffer-name))
 
 (defun switch-to-raku (eob-p)
-  "Switch to the Raku REPL buffer, starting one if necessary.
+  "Start a Raku REPL, or switch to a running one.
 Reuses an existing REPL window if visible, otherwise switches in current window.
 With prefix argument EOB-P, move point to the end of the buffer."
   (interactive "P")

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -63,17 +63,16 @@
   (get-process raku-buffer-name))
 
 (defun switch-to-raku (eob-p)
-  "Start a Raku REPL, or switch to a running one.
-Reuses an existing REPL window if visible, otherwise switches in
-current window. With prefix argument EOB-P, move point to the end of
-the buffer."
+  "Switch to the Raku REPL buffer, starting one if necessary."
   (interactive "P")
   (let* ((buf-name (format "*%s*" raku-buffer-name))
-         (buf (get-buffer buf-name))
-         (win (and buf (get-buffer-window buf))))
-    (if win
-        (select-window win)
-      (switch-to-buffer (get-buffer-create buf-name))))
+         (buf (get-buffer-create buf-name))
+         (win (get-buffer-window buf)))
+    (if (eq (selected-window) win)
+        (other-window -1)
+      (if win
+          (select-window win)
+        (switch-to-buffer-other-window buf))))
   (unless (process-live-p (raku-comint-get-process))
     (run-raku))
   (when eob-p

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -62,6 +62,23 @@
   "Raku process name."
   (get-process raku-buffer-name))
 
+(defun raku-switch-to-raku (eob-p)
+  "Switch to the Raku REPL buffer, starting one if necessary.
+Reuses an existing REPL window if visible, otherwise switches in current window.
+With prefix argument EOB-P, move point to the end of the buffer."
+  (interactive "P")
+  (let* ((buf-name (format "*%s*" raku-buffer-name))
+         (buf (get-buffer buf-name))
+         (win (and buf (get-buffer-window buf))))
+    (if win
+        (select-window win)
+      (switch-to-buffer (get-buffer-create buf-name))))
+  (unless (process-live-p (raku-comint-get-process))
+    (run-raku))
+  (when eob-p
+    (push-mark)
+    (goto-char (point-max))))
+
 (defun raku-send-string-to-repl (str)
   "Send STR to the repl."
   (comint-send-string (raku-comint-get-process)

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -62,7 +62,7 @@
   "Raku process name."
   (get-process raku-buffer-name))
 
-(defun raku-switch-to-raku (eob-p)
+(defun switch-to-raku (eob-p)
   "Switch to the Raku REPL buffer, starting one if necessary.
 Reuses an existing REPL window if visible, otherwise switches in current window.
 With prefix argument EOB-P, move point to the end of the buffer."

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -7,6 +7,8 @@
 (require 'comint)
 (require 'raku-font-lock)
 
+(define-key raku-repl-mode-map (kbd "C-c C-z") #'switch-to-raku)
+
 (defcustom raku-exec-path "raku"
   "Raku executable path."
   :type 'string

--- a/raku-repl.el
+++ b/raku-repl.el
@@ -64,8 +64,9 @@
 
 (defun switch-to-raku (eob-p)
   "Start a Raku REPL, or switch to a running one.
-Reuses an existing REPL window if visible, otherwise switches in current window.
-With prefix argument EOB-P, move point to the end of the buffer."
+Reuses an existing REPL window if visible, otherwise switches in
+current window.  With prefix argument EOB-P, move point to the end of
+the buffer."
   (interactive "P")
   (let* ((buf-name (format "*%s*" raku-buffer-name))
          (buf (get-buffer buf-name))


### PR DESCRIPTION
Much like other emacs packages that include REPL's, add a switch-to-raku function binded to C-c C-z.